### PR TITLE
Added environmental variables to sagemath kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sage-notebook [![Build Status](https://travis-ci.org/sharpTrick/sage-notebook.svg?branch=master)](https://travis-ci.org/sharpTrick/sage-notebook)
 sage-notebook is a community maintained Jupyter Docker Stack image with the sagemath kernel.
 
-Like jupyter packages in the base image, the sagemath environment is installed via conda from conda-forge as per http://doc.sagemath.org/html/en/installation/conda.html and the sagemath kernel is executed in this environment by invoking [`conda run -n sage ...`](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html?highlight=%22conda%20run%22#activating-an-environment).
+Like jupyter packages in the base image, the sagemath environment is installed via conda from conda-forge as per http://doc.sagemath.org/html/en/installation/conda.html. Sagemath's environmental variables are added to the sagemath kernel so that it can be cleanly executed by jupyter while still allowing sagemath to maintain its own curated collection of libraries.
 
 Development of conda sage packages appears to be tracked at https://wiki.sagemath.org/Conda
 


### PR DESCRIPTION
This method is in place of using "conda run -n sage ..."
For some reason this makes the nbextentions such as jsmol to work